### PR TITLE
Fix unit test failures in SQL validation rubrics

### DIFF
--- a/src/rubrics/batch_scorer.py
+++ b/src/rubrics/batch_scorer.py
@@ -235,6 +235,16 @@ class BatchSQLScorer:
                 results.append({
                     "index": i,
                     "total": 0.0,
+                    "syntax": 0.0,
+                    "syntax_valid": False,
+                    "keywords": 0.0,
+                    "format": 0.0,
+                    "extracted_sql": None,
+                    "weights": {
+                        "syntax": self.rubric.syntax_weight,
+                        "keywords": self.rubric.keyword_weight,
+                        "format": self.rubric.format_weight,
+                    },
                     "error": str(e),
                 })
 

--- a/src/rubrics/sql_rubric.py
+++ b/src/rubrics/sql_rubric.py
@@ -185,7 +185,7 @@ class SQLValidationRubric:
 
             for pattern in error_patterns:
                 if pattern in sql_upper:
-                    return False, 0.3  # Partial credit for attempt
+                    return False, 0.2  # Partial credit for attempt
 
             # If we got here, SQL is syntactically valid
             return True, 1.0

--- a/src/utils/sql_parser.py
+++ b/src/utils/sql_parser.py
@@ -126,8 +126,9 @@ class SQLParser:
         """
         matches = self.INLINE_CODE_PATTERN.findall(text)
         for match in matches:
-            if self.detect_sql_pattern(match):
-                return self.clean_sql(match)
+            match_stripped = match.strip()
+            if self.detect_sql_pattern(match_stripped):
+                return self.clean_sql(match_stripped)
         return None
 
     def _extract_raw_sql(self, text: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
Fixed 4 failing unit tests in the SQL validation rubrics:

1. `test_extract_inline_code` - Fixed inline SQL extraction
2. `test_score_invalid_sql` - Adjusted scoring for invalid SQL
3. `test_compute_batch_statistics` - Fixed metadata KeyError
4. `test_end_to_end_pipeline` - Fixed metadata KeyError

## Changes
- Fixed inline SQL extraction to properly handle backtick patterns
- Adjusted syntax error partial credit from 0.3 to 0.2 for invalid SQL
- Fixed metadata error handling to include all required fields

Fixes #8

Generated with [Claude Code](https://claude.ai/code)