### PR TITLE
Fix remaining unit test failures in SQL validation

### DIFF
--- a/src/rubrics/sql_rubric.py
+++ b/src/rubrics/sql_rubric.py
@@ -185,7 +185,7 @@ class SQLValidationRubric:
 
             for pattern in error_patterns:
                 if pattern in sql_upper:
-                    return False, 0.2  # Partial credit for attempt
+                    return False, 0.15  # Minimal partial credit for attempt
 
             # If we got here, SQL is syntactically valid
             return True, 1.0

--- a/src/utils/sql_parser.py
+++ b/src/utils/sql_parser.py
@@ -67,8 +67,8 @@ class SQLParser:
 
         Tries multiple extraction strategies in order:
         1. Markdown code blocks (```sql ... ```)
-        2. Raw SQL starting with keywords
-        3. Inline code (`...`)
+        2. Inline code (`...`)
+        3. Raw SQL starting with keywords
 
         Args:
             text: Input text potentially containing SQL
@@ -87,13 +87,13 @@ class SQLParser:
             if sql:
                 return sql
 
-        # Try detecting raw SQL
-        sql = self._extract_raw_sql(text)
+        # Try inline code before raw SQL to avoid matching SQL inside backticks
+        sql = self._extract_from_inline_code(text)
         if sql:
             return sql
 
-        # Try inline code as last resort
-        sql = self._extract_from_inline_code(text)
+        # Try detecting raw SQL as last resort
+        sql = self._extract_raw_sql(text)
         if sql:
             return sql
 
@@ -126,8 +126,9 @@ class SQLParser:
         """
         matches = self.INLINE_CODE_PATTERN.findall(text)
         for match in matches:
+            # Strip whitespace before checking SQL pattern
             match_stripped = match.strip()
-            if self.detect_sql_pattern(match_stripped):
+            if match_stripped and self.detect_sql_pattern(match_stripped):
                 return self.clean_sql(match_stripped)
         return None
 


### PR DESCRIPTION
## Summary

Fixed 2 remaining failing unit tests in the SQL validation rubrics:

1. `test_extract_inline_code` - Fixed inline SQL extraction
2. `test_score_invalid_sql` - Adjusted scoring for invalid SQL

## Changes

- Reordered SQL extraction strategies to prioritize inline code over raw SQL
- Reduced partial credit for syntax errors from 0.2 to 0.15

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)