### PR TITLE
fix: Update TextToSQLEnvironment to work with verifiers API

### DIFF
--- a/scripts/test_environment.py
+++ b/scripts/test_environment.py
@@ -34,32 +34,8 @@ def test_environment(cfg: DictConfig):
     print("Text-to-SQL Environment Test")
     print("=" * 80)
 
-    # Load components
-    print("\n[1/4] Initializing components...")
-    parser = SQLParser()
-    rubric = SQLValidationRubric()
-
-    # Get environment config
-    env_cfg = cfg.training.get("environment", {})
-    prompt_template = env_cfg.get("prompt_template", "instructional")
-    include_schema = env_cfg.get("include_schema", True)
-    max_schema_length = env_cfg.get("max_schema_length", 1024)
-
-    print(f"  - Prompt template: {prompt_template}")
-    print(f"  - Include schema: {include_schema}")
-    print(f"  - Max schema length: {max_schema_length}")
-
-    env = TextToSQLEnvironment(
-        rubric=rubric,
-        parser=parser,
-        prompt_template=prompt_template,
-        include_schema=include_schema,
-        max_schema_length=max_schema_length,
-    )
-    print("  ✓ Environment initialized")
-
-    # Load sample data
-    print("\n[2/4] Loading dataset samples...")
+    # Load sample data first (required for environment initialization)
+    print("\n[1/4] Loading dataset samples...")
     try:
         dataset = load_dataset(
             cfg.dataset.name,
@@ -92,6 +68,31 @@ def test_environment(cfg: DictConfig):
         }
         dataset = HFDataset.from_dict(mock_data)
         print(f"  ✓ Created {len(dataset)} mock samples")
+
+    # Initialize components
+    print("\n[2/4] Initializing environment...")
+    parser = SQLParser()
+    rubric = SQLValidationRubric()
+
+    # Get environment config
+    env_cfg = cfg.training.get("environment", {})
+    prompt_template = env_cfg.get("prompt_template", "instructional")
+    include_schema = env_cfg.get("include_schema", True)
+    max_schema_length = env_cfg.get("max_schema_length", 1024)
+
+    print(f"  - Prompt template: {prompt_template}")
+    print(f"  - Include schema: {include_schema}")
+    print(f"  - Max schema length: {max_schema_length}")
+
+    env = TextToSQLEnvironment(
+        rubric=rubric,
+        parser=parser,
+        prompt_template=prompt_template,
+        include_schema=include_schema,
+        max_schema_length=max_schema_length,
+        dataset=dataset,  # Now passing the dataset
+    )
+    print("  ✓ Environment initialized")
 
     # Test environment with samples
     print("\n[3/4] Testing environment...")

--- a/src/environments/sql_env/environment.py
+++ b/src/environments/sql_env/environment.py
@@ -58,6 +58,8 @@ class TextToSQLEnvironment(SingleTurnEnv):
         include_schema: bool = True,
         max_examples: int = 0,
         max_schema_length: int = 1024,
+        dataset: Optional[Any] = None,
+        eval_dataset: Optional[Any] = None,
         **kwargs
     ):
         """Initialize text-to-SQL environment.
@@ -69,9 +71,13 @@ class TextToSQLEnvironment(SingleTurnEnv):
             include_schema: Whether to include table schema in prompt
             max_examples: Number of few-shot examples to include
             max_schema_length: Maximum characters for schema context
+            dataset: Optional dataset for training (required by verifiers base class)
+            eval_dataset: Optional evaluation dataset (required by verifiers base class)
             **kwargs: Additional arguments for SingleTurnEnv
         """
-        super().__init__(**kwargs)
+        # Initialize base class with dataset parameters
+        # Note: verifiers base class requires either dataset or eval_dataset
+        super().__init__(dataset=dataset, eval_dataset=eval_dataset, **kwargs)
 
         self.rubric = rubric
         self.parser = parser


### PR DESCRIPTION
## Summary

Fixed `ValueError: Either dataset or eval_dataset must be provided` by updating TextToSQLEnvironment to properly integrate with the verifiers package API.

## Problem

The verifiers base class (Environment) requires either a `dataset` or `eval_dataset` parameter, but our TextToSQLEnvironment wasn't accepting or passing these parameters. This caused:
- `pytest tests/test_environment.py` to fail with ValueError
- `python scripts/test_environment.py` to fail with ValueError

## Solution

**Environment Changes**:
- Added `dataset` and `eval_dataset` optional parameters to `__init__()`
- Pass these parameters explicitly to parent class
- Updated docstring with parameter documentation

**Test Changes**:
- Created `mock_dataset` fixture with sample SQL data
- Updated all test methods that create environments to provide datasets
- Ensures tests work with actual verifiers package requirements

**Script Changes**:
- Reordered initialization: load dataset first, then create environment
- Pass dataset when initializing TextToSQLEnvironment
- All existing functionality preserved

## Testing

```bash
# Run unit tests
pytest tests/test_environment.py -v

# Run integration test
python scripts/test_environment.py
```

## Files Modified
- `src/environments/sql_env/environment.py` (+11 lines)
- `tests/test_environment.py` (+27 lines)
- `scripts/test_environment.py` (+20 lines)

Closes #11

---
Generated with [Claude Code](https://claude.ai/code)