### PR TITLE
fix: resolve test failures in TextToSQLEnvironment

### DIFF
--- a/src/environments/sql_env/environment.py
+++ b/src/environments/sql_env/environment.py
@@ -5,6 +5,7 @@ handling prompt formatting, response parsing, and reward computation.
 """
 
 import logging
+import re
 from typing import Dict, List, Any, Optional
 
 from verifiers import SingleTurnEnv
@@ -102,6 +103,13 @@ class TextToSQLEnvironment(SingleTurnEnv):
         # Check if it's a template name
         if template in PROMPT_TEMPLATES:
             return get_prompt_template(template)
+
+        # Check if this looks like an invalid template name
+        # (single word without spaces or special characters that looks like a name)
+        if re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', template):
+            raise ValueError(
+                f"Unknown template: '{template}'. Available templates: {', '.join(PROMPT_TEMPLATES.keys())}"
+            )
 
         # Otherwise, treat as custom template
         # Validate it has required placeholders

--- a/src/environments/sql_env/utils.py
+++ b/src/environments/sql_env/utils.py
@@ -40,7 +40,9 @@ def extract_schema_info(context: str) -> Dict[str, List[str]]:
 
         # Extract column names
         # Pattern to match column definitions: column_name TYPE [constraints]
-        column_pattern = r"[`\"]?(\w+)[`\"]?\s+(?:INT|INTEGER|VARCHAR|TEXT|CHAR|DECIMAL|NUMERIC|FLOAT|DOUBLE|REAL|DATE|DATETIME|TIMESTAMP|TIME|BOOLEAN|BOOL|BLOB|CLOB)"
+        # Note: Order matters - longer patterns first to avoid partial matches
+        # VARCHAR(100), DATETIME, TIMESTAMP must come before VARCHAR, DATE, TIME, TEXT
+        column_pattern = r"[`\"]?(\w+)[`\"]?\s+(?:DATETIME|TIMESTAMP|VARCHAR\s*(?:\(\d+\))?|INTEGER|DECIMAL|NUMERIC|BOOLEAN|DOUBLE|FLOAT|REAL|CHAR|TEXT|TIME|DATE|INT|BOOL|BLOB|CLOB)"
 
         columns = re.findall(column_pattern, columns_text, re.IGNORECASE)
 


### PR DESCRIPTION
### Summary

Fixed 2 failing unit tests in the TextToSQLEnvironment implementation.

### Changes

**Test Failure 1**: `test_initialization_with_invalid_template`
- Added validation to detect invalid template names vs custom templates
- Now raises `ValueError` with "Unknown template" message as expected
- Provides helpful error listing available templates

**Test Failure 2**: `test_extract_schema_info`
- Fixed regex pattern for SQL data type matching
- Reordered types (longest first) to avoid partial matches
- Added optional parentheses handling for `VARCHAR(n)`
- Now correctly extracts columns with TEXT data type

### Files Modified
- `src/environments/sql_env/environment.py`
- `src/environments/sql_env/utils.py`

### Testing

```bash
pytest tests/test_environment.py -v
```

All 39 tests should now pass.

Closes #11

---
Generated with [Claude Code](https://claude.ai/code)