### PR TITLE
fix: replace word boundary with explicit lookahead in column pattern

### DIFF
--- a/src/environments/sql_env/utils.py
+++ b/src/environments/sql_env/utils.py
@@ -42,8 +42,8 @@ def extract_schema_info(context: str) -> Dict[str, List[str]]:
         # Pattern to match column definitions: column_name TYPE [constraints]
         # Note: Order matters - longer patterns first to avoid partial matches
         # VARCHAR(100), DATETIME, TIMESTAMP must come before VARCHAR, DATE, TIME, TEXT
-        # Word boundary \b at end ensures we match complete type names
-        column_pattern = r"[`\"]?(\w+)[`\"]?\s+(?:DATETIME|TIMESTAMP|VARCHAR\s*(?:\(\d+\))?|INTEGER|DECIMAL|NUMERIC|BOOLEAN|DOUBLE|FLOAT|REAL|CHAR|TEXT|TIME|DATE|INT|BOOL|BLOB|CLOB)\b"
+        # Positive lookahead (?=...) ensures type is followed by valid separator without consuming it
+        column_pattern = r"[`\"]?(\w+)[`\"]?\s+(?:DATETIME|TIMESTAMP|VARCHAR\s*(?:\(\d+\))?|INTEGER|DECIMAL|NUMERIC|BOOLEAN|DOUBLE|FLOAT|REAL|CHAR|TEXT|TIME|DATE|INT|BOOL|BLOB|CLOB)(?=\s|,|\)|$)"
 
         columns = re.findall(column_pattern, columns_text, re.IGNORECASE)
 


### PR DESCRIPTION
### Summary

Fixed the column extraction regex pattern in `extract_schema_info()` to correctly capture the last column in CREATE TABLE statements.

### Problem

The previous fix using word boundary `\b` did not resolve the issue. The test `test_extract_schema_info` continued to fail because the last column (`email TEXT`) was not being matched when followed immediately by a closing parenthesis.

### Solution

Replaced the word boundary `\b` with a positive lookahead `(?=\s|,|\)|$)` that explicitly checks for:
- Whitespace
- Comma
- Closing parenthesis
- End of string

This ensures the regex correctly matches all column definitions regardless of what follows the data type.

### Files Changed
- `src/environments/sql_env/utils.py` (+2 lines, -2 lines)

### Testing

```bash
pytest tests/test_environment.py::TestSchemaExtraction::test_extract_schema_info -v
```

Related to #15

---
🤖 Generated with [Claude Code](https://claude.ai/code)