### PR TITLE
fix: refactor column extraction to use split-then-match approach

### DIFF
--- a/src/environments/sql_env/utils.py
+++ b/src/environments/sql_env/utils.py
@@ -38,14 +38,22 @@ def extract_schema_info(context: str) -> Dict[str, List[str]]:
         table_name = match.group(1)
         columns_text = match.group(2)
 
-        # Extract column names
-        # Pattern to match column definitions: column_name TYPE [constraints]
-        # Note: Order matters - longer patterns first to avoid partial matches
-        # VARCHAR(100), DATETIME, TIMESTAMP must come before VARCHAR, DATE, TIME, TEXT
-        # Positive lookahead (?=...) ensures type is followed by valid separator without consuming it
-        column_pattern = r"[`\"]?(\w+)[`\"]?\s+(?:DATETIME|TIMESTAMP|VARCHAR\s*(?:\(\d+\))?|INTEGER|DECIMAL|NUMERIC|BOOLEAN|DOUBLE|FLOAT|REAL|CHAR|TEXT|TIME|DATE|INT|BOOL|BLOB|CLOB)(?=\s|,|\)|$)"
+        # Extract column names using a more robust pattern
+        # Split on commas first, then extract column name and type from each part
+        column_defs = columns_text.split(',')
+        columns = []
 
-        columns = re.findall(column_pattern, columns_text, re.IGNORECASE)
+        for col_def in column_defs:
+            col_def = col_def.strip()
+            # Match column_name at the start, followed by a data type
+            # Pattern captures just the column name
+            match = re.match(
+                r'[`\"]?(\w+)[`\"]?\s+(?:VARCHAR(?:\s*\(\d+\))?|DATETIME|TIMESTAMP|INTEGER|DECIMAL|NUMERIC|BOOLEAN|DOUBLE|FLOAT|REAL|CHAR|TEXT|TIME|DATE|INT|BOOL|BLOB|CLOB)',
+                col_def,
+                re.IGNORECASE
+            )
+            if match:
+                columns.append(match.group(1))
 
         if columns:
             schema_info[table_name] = columns


### PR DESCRIPTION
### Summary

Fixed the column extraction regex pattern in `extract_schema_info()` to correctly capture all columns in CREATE TABLE statements.

### Problem

The previous fix using lookahead `(?=\s|,|\)|$)` interfered with `re.findall` and only captured the first column. The test `test_extract_schema_info` failed with only `['id']` instead of the expected `['id', 'name', 'email']`.

### Root Cause

- Lookahead patterns interfered with how `re.findall` advanced through the string
- Word boundary `\b` doesn't exist between two non-word characters like `)` and `,`

### Solution

Implemented a more robust two-step approach:
1. Split column definitions on commas first
2. Match each definition individually using `re.match()`

This correctly handles:
- Types with parentheses (VARCHAR(100))
- Last column followed by closing parenthesis
- All delimiter combinations

### Files Changed
- `src/environments/sql_env/utils.py` (+16 lines, -8 lines)

### Testing

```bash
pytest tests/test_environment.py::TestSchemaExtraction::test_extract_schema_info -v
```

Related to #15

---
🤖 Generated with [Claude Code](https://claude.ai/code)