### PR TITLE
fix: use greedy regex to handle nested parentheses

### DIFF
--- a/src/environments/sql_env/utils.py
+++ b/src/environments/sql_env/utils.py
@@ -30,7 +30,8 @@ def extract_schema_info(context: str) -> Dict[str, List[str]]:
 
     # Pattern to match CREATE TABLE statements
     # Matches: CREATE TABLE table_name (columns...)
-    table_pattern = r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`\"]?(\w+)[`\"]?\s*\((.*?)\)"
+    # Use greedy .* to capture until the last closing paren (handles nested parens in types like VARCHAR(100))
+    table_pattern = r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`\"]?(\w+)[`\"]?\s*\((.*)\)"
 
     matches = re.finditer(table_pattern, context, re.IGNORECASE | re.DOTALL)
 


### PR DESCRIPTION
### Summary

Fixed the table pattern regex to correctly extract all columns when data types contain nested parentheses (like VARCHAR(100)).

### Problem

The test `test_extract_schema_info` was failing because only `['id', 'name']` were captured instead of `['id', 'name', 'email']`.

### Root Cause

The non-greedy regex `(.*?)` in the table pattern was stopping at the first closing parenthesis, which was inside `VARCHAR(100)`, causing columns after it to be truncated.

### Solution

Changed `(.*?)` to greedy `(.*)` so it captures all columns until the final closing parenthesis.

### Files Changed
- `src/environments/sql_env/utils.py` (line 34)

Related to #18

---
🤖 Generated with [Claude Code](https://claude.ai/code)