### PR TITLE
fix: prevent regex from matching across multiple CREATE TABLE statements

### DIFF
--- a/src/environments/sql_env/utils.py
+++ b/src/environments/sql_env/utils.py
@@ -30,10 +30,11 @@ def extract_schema_info(context: str) -> Dict[str, List[str]]:
 
     # Pattern to match CREATE TABLE statements
     # Matches: CREATE TABLE table_name (columns...)
-    # Use greedy .* to capture until the last closing paren (handles nested parens in types like VARCHAR(100))
-    table_pattern = r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`\"]?(\w+)[`\"]?\s*\((.*)\)"
+    # Use greedy .* but stop at semicolon to avoid matching across multiple tables
+    # This handles nested parens in types like VARCHAR(100) while respecting statement boundaries
+    table_pattern = r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`\"]?(\w+)[`\"]?\s*\(([^;]*)\)"
 
-    matches = re.finditer(table_pattern, context, re.IGNORECASE | re.DOTALL)
+    matches = re.finditer(table_pattern, context, re.IGNORECASE)
 
     for match in matches:
         table_name = match.group(1)


### PR DESCRIPTION
### Summary

Fixed the regex pattern to correctly handle both nested parentheses in data types AND multiple CREATE TABLE statements.

### Problem

The previous fix in PR #19 used greedy `(.*)` with `re.DOTALL` which caused the pattern to match from the first opening parenthesis to the LAST closing parenthesis across the entire text, breaking multi-table extraction.

This caused two tests to fail:
- `test_extract_schema_info_multiple_tables` - only 1 table extracted instead of 2
- `test_get_table_names` - only 1 table name extracted instead of 2

### Solution

Changed to use `([^;]*)` character class that matches everything except semicolons, preventing the pattern from bleeding across statement boundaries while still handling nested parentheses like VARCHAR(100).

### Files Changed
- `src/environments/sql_env/utils.py` (lines 35-37)

### Tests Fixed
- ✓ `test_extract_schema_info` (nested parentheses)
- ✓ `test_extract_schema_info_multiple_tables` (multiple tables)
- ✓ `test_get_table_names` (table name extraction)

Related to #19

---
🤖 Generated with [Claude Code](https://claude.ai/code)