### PR TITLE
fix: Add mock dataset to TextToSQLEnvironment initialization in tests

### DIFF
--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -277,7 +277,15 @@ def test_grpo_formatting():
 
     rubric = SQLValidationRubric()
     parser = SQLParser()
-    env = TextToSQLEnvironment(rubric=rubric, parser=parser)
+
+    # Create a minimal mock dataset (required by verifiers base class)
+    mock_dataset = Dataset.from_dict({
+        'question': ['Mock question?'],
+        'context': ['CREATE TABLE mock (id INT)'],
+        'answer': ['SELECT * FROM mock']
+    })
+
+    env = TextToSQLEnvironment(rubric=rubric, parser=parser, dataset=mock_dataset)
 
     # Create a mock tokenizer
     class MockTokenizer:
@@ -320,7 +328,15 @@ def test_tokenization_validation():
 
     rubric = SQLValidationRubric()
     parser = SQLParser()
-    env = TextToSQLEnvironment(rubric=rubric, parser=parser)
+
+    # Create a minimal mock dataset (required by verifiers base class)
+    mock_dataset = Dataset.from_dict({
+        'question': ['Mock question?'],
+        'context': ['CREATE TABLE mock (id INT)'],
+        'answer': ['SELECT * FROM mock']
+    })
+
+    env = TextToSQLEnvironment(rubric=rubric, parser=parser, dataset=mock_dataset)
 
     class MockTokenizer:
         def encode(self, text, add_special_tokens=True):
@@ -353,7 +369,15 @@ def test_evaluation_set_creation():
 
     rubric = SQLValidationRubric()
     parser = SQLParser()
-    env = TextToSQLEnvironment(rubric=rubric, parser=parser)
+
+    # Create a minimal mock dataset (required by verifiers base class)
+    mock_dataset = Dataset.from_dict({
+        'question': ['Mock question?'],
+        'context': ['CREATE TABLE mock (id INT)'],
+        'answer': ['SELECT * FROM mock']
+    })
+
+    env = TextToSQLEnvironment(rubric=rubric, parser=parser, dataset=mock_dataset)
 
     class MockTokenizer:
         def encode(self, text, add_special_tokens=True):
@@ -407,7 +431,15 @@ def test_full_pipeline():
 
     rubric = SQLValidationRubric()
     parser = SQLParser()
-    env = TextToSQLEnvironment(rubric=rubric, parser=parser)
+
+    # Create a minimal mock dataset (required by verifiers base class)
+    mock_dataset = Dataset.from_dict({
+        'question': ['Mock question?'],
+        'context': ['CREATE TABLE mock (id INT)'],
+        'answer': ['SELECT * FROM mock']
+    })
+
+    env = TextToSQLEnvironment(rubric=rubric, parser=parser, dataset=mock_dataset)
 
     class MockTokenizer:
         def encode(self, text, add_special_tokens=True):


### PR DESCRIPTION
## Summary

Fixed ValueError in `test_data_pipeline.py` by providing the required `dataset` parameter when instantiating `TextToSQLEnvironment`. The verifiers base class requires either `dataset` or `eval_dataset` to be provided.

## Changes

Added minimal mock dataset initialization in four failing tests:
- `test_grpo_formatting`
- `test_tokenization_validation`
- `test_evaluation_set_creation`
- `test_full_pipeline`

## Root Cause

The `TextToSQLEnvironment` class inherits from `SingleTurnEnv` (verifiers package), which validates that at least one of `dataset` or `eval_dataset` is provided in the constructor. Tests were creating the environment without any dataset, causing `ValueError: Either dataset or eval_dataset must be provided`.

## Testing

Run the tests to verify:
```bash
pytest tests/test_data_pipeline.py -v
```

All 14 tests should now pass.

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)