### PR TITLE
fix: Update test assertions for PEFT target_modules set behavior

### DIFF
--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -66,7 +66,7 @@ class TestModelLoader:
         assert config.r == 16
         assert config.lora_alpha == 32
         assert config.lora_dropout == 0.05
-        assert config.target_modules == ["q_proj", "v_proj"]
+        assert config.target_modules == {"q_proj", "v_proj"}
         assert config.bias == "none"
 
     def test_lora_config_default_target_modules(self):
@@ -301,7 +301,7 @@ class TestConfigUtils:
         assert config.r == 32
         assert config.lora_alpha == 64
         assert config.lora_dropout == 0.1
-        assert config.target_modules == ["q_proj", "v_proj", "k_proj"]
+        assert config.target_modules == {"q_proj", "v_proj", "k_proj"}
 
     def test_memory_estimation(self):
         """Test memory requirement estimation."""


### PR DESCRIPTION
Fixes test failures in `test_model_loading.py` by updating assertions to use set comparison for `target_modules`.

## Changes
- Updated line 69: Changed list comparison to set comparison
- Updated line 304: Changed list comparison to set comparison

## Reason
The PEFT library returns `target_modules` as a set rather than a list for efficiency. The tests were expecting lists, causing assertion failures.

Related to #25

Generated with [Claude Code](https://claude.ai/code)