### PR TITLE
fix: Make Flash Attention 2 optional with graceful fallback

### DIFF
--- a/config/hf/hf.yaml
+++ b/config/hf/hf.yaml
@@ -5,7 +5,9 @@ model:
   device_map: auto
 
   # Attention implementation
-  attn_implementation: flash_attention_2  # Requires flash-attn package
+  # Options: "auto" (try flash_attention_2, fallback to default), "flash_attention_2", "sdpa", "eager", null
+  # "auto" is recommended - uses flash-attn if available, falls back gracefully if not
+  attn_implementation: auto
 
   # Torch dtype for non-quantized loading
   torch_dtype: bfloat16

--- a/scripts/test_model.py
+++ b/scripts/test_model.py
@@ -9,6 +9,10 @@ from omegaconf import DictConfig
 import torch
 import sys
 from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables before anything else
+load_dotenv()
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -52,11 +56,15 @@ def test_model(cfg: DictConfig):
     bnb_config = create_bnb_config_from_hydra(cfg)
     lora_config = create_lora_config_from_hydra(cfg)
 
+    # Get attention implementation from config if available
+    attn_impl = cfg.hf.model.get('attn_implementation', 'auto')
+
     model, tokenizer = loader.load_model_and_tokenizer(
         use_quantization=cfg.training.peft.use_qlora,
         use_peft=cfg.training.use_peft,
         bnb_config=bnb_config,
-        lora_config=lora_config
+        lora_config=lora_config,
+        attn_implementation=attn_impl
     )
 
     # Print model info

--- a/src/models/config_utils.py
+++ b/src/models/config_utils.py
@@ -28,6 +28,10 @@ def create_model_config_from_hydra(cfg: DictConfig) -> Dict:
         "use_peft": cfg.training.use_peft,
     }
 
+    # Add attention implementation if specified in config
+    if hasattr(cfg.hf.model, 'attn_implementation'):
+        model_config["attn_implementation"] = cfg.hf.model.attn_implementation
+
     return model_config
 
 


### PR DESCRIPTION
Fixes Flash Attention import error by making it optional with graceful fallback.

## Changes
- Add attn_implementation parameter to ModelLoader.load_model() with 'auto' default
- Implement smart detection to test flash_attn import and fall back gracefully
- Add exception handling for flash-attn errors during model loading
- Update config/hf/hf.yaml to use 'auto' mode instead of hardcoded flash_attention_2
- Update config_utils to pass through attn_implementation from Hydra config
- Add load_dotenv() to test_model.py for HF_TOKEN authentication
- Enhanced logging to inform users about attention implementation

## Benefits
- Works on all systems regardless of flash-attn installation status
- Maintains 2-3x performance boost when flash-attn is properly installed
- No breaking changes for existing code
- Clear logging about attention implementation being used

Related to #25

Generated with [Claude Code](https://claude.ai/code)