### PR TITLE
fix: Remove invalid GRPOConfig parameters and fix test fixtures

### DIFF
--- a/src/training/config_builder.py
+++ b/src/training/config_builder.py
@@ -55,16 +55,8 @@ class GRPOConfigBuilder:
             fp16=False,  # Use bf16 instead
             gradient_checkpointing=cfg.training.gradient_checkpointing,
 
-            # Generation parameters
-            max_new_tokens=cfg.training.max_new_tokens,
-            temperature=cfg.training.temperature,
-            top_p=cfg.training.top_p,
-            do_sample=cfg.training.do_sample,
-
             # GRPO-specific parameters
             num_generations=cfg.training.num_generations,
-            kl_coef=cfg.training.kl_coef,
-            gamma=cfg.training.gamma,
 
             # Checkpointing
             save_strategy=cfg.training.save_strategy,

--- a/src/training/grpo_trainer.py
+++ b/src/training/grpo_trainer.py
@@ -89,11 +89,6 @@ class SQLGRPOTrainer:
             gradient_checkpointing=True,
             # GRPO-specific
             num_generations=4,
-            kl_coef=0.05,
-            gamma=1.0,
-            max_new_tokens=256,
-            temperature=0.7,
-            top_p=0.9,
         )
 
     def compute_rewards(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -45,12 +45,13 @@ def sql_rubric(sql_parser):
 
 
 @pytest.fixture
-def text_to_sql_env(sql_rubric, sql_parser):
+def text_to_sql_env(sql_rubric, sql_parser, sample_dataset):
     """Create text-to-SQL environment."""
     return TextToSQLEnvironment(
         rubric=sql_rubric,
         parser=sql_parser,
-        prompt_template="default"
+        prompt_template="default",
+        dataset=sample_dataset
     )
 
 
@@ -127,8 +128,6 @@ def test_grpo_config_creation():
     assert config.gradient_accumulation_steps == 8
     assert config.learning_rate == 5e-6
     assert config.num_generations == 4
-    assert config.kl_coef == 0.05
-    assert config.gamma == 1.0
 
 
 def test_grpo_config_from_hydra(hydra_config):
@@ -140,7 +139,6 @@ def test_grpo_config_from_hydra(hydra_config):
     assert config.num_train_epochs == 3
     assert config.learning_rate == 5e-6
     assert config.num_generations == 4
-    assert config.kl_coef == 0.05
     assert config.seed == 42
     assert config.report_to == []
 


### PR DESCRIPTION
### Summary

Fixed test failures in `tests/test_training.py` by removing invalid parameters from GRPOConfig initialization and fixing test fixtures.

### Changes

- **src/training/grpo_trainer.py**: Removed invalid parameters (`kl_coef`, `gamma`, `max_new_tokens`, `temperature`, `top_p`, `do_sample`) from `create_default_config()`
- **src/training/config_builder.py**: Removed same invalid parameters from `build_from_hydra()`
- **tests/test_training.py**: Fixed `text_to_sql_env` fixture to provide required `dataset` parameter and updated test assertions

### Root Cause

TRL's GRPOConfig doesn't accept generation parameters (temperature, top_p, etc.) as constructor arguments. These should be configured separately through model.generation_config or passed to generation methods.

### Testing

```bash
pytest tests/test_training.py -v
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)