### PR TITLE
fix: Update GRPOTrainer and GRPOConfig to match TRL API

### DIFF
--- a/src/training/config_builder.py
+++ b/src/training/config_builder.py
@@ -64,7 +64,7 @@ class GRPOConfigBuilder:
             save_total_limit=cfg.training.save_total_limit,
 
             # Evaluation
-            evaluation_strategy=cfg.training.evaluation_strategy,
+            eval_strategy=cfg.training.evaluation_strategy,
             eval_steps=cfg.training.eval_steps,
 
             # Miscellaneous

--- a/src/training/grpo_trainer.py
+++ b/src/training/grpo_trainer.py
@@ -61,10 +61,11 @@ class SQLGRPOTrainer:
         self.config = config
 
         # Initialize TRL's GRPOTrainer
+        # Note: tokenizer is stored in the class but not passed to GRPOTrainer
+        # as it's handled internally by TRL's trainer
         self.trainer = GRPOTrainer(
             model=model,
-            tokenizer=tokenizer,
-            config=config,
+            args=config,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             reward_function=self.compute_rewards,


### PR DESCRIPTION
### Summary

Fixed test failures by updating code to match TRL library's actual API.

### Changes

- **src/training/grpo_trainer.py**: Removed `tokenizer` parameter and changed `config` to `args` in GRPOTrainer initialization
- **src/training/config_builder.py**: Changed `evaluation_strategy` to `eval_strategy` in GRPOConfig

### Root Cause

The TRL library's GRPOTrainer and GRPOConfig have different parameter names than originally implemented:
- GRPOTrainer expects `args` instead of `config`
- GRPOTrainer doesn't accept `tokenizer` as a constructor parameter
- GRPOConfig uses `eval_strategy` instead of `evaluation_strategy`

### Testing

```bash
pytest tests/test_training.py -v
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)