### PR TITLE
fix: Add required reward_funcs parameter to GRPOTrainer

### DIFF
--- a/src/training/grpo_trainer.py
+++ b/src/training/grpo_trainer.py
@@ -63,12 +63,13 @@ class SQLGRPOTrainer:
         # Initialize TRL's GRPOTrainer
         # Note: tokenizer is stored in the class but not passed to GRPOTrainer
         # as it's handled internally by TRL's trainer
-        # Note: reward computation is handled separately, not via constructor
+        # Note: reward_funcs expects a list of reward functions
         self.trainer = GRPOTrainer(
             model=model,
             args=config,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
+            reward_funcs=[self.compute_rewards],
             **kwargs
         )
 


### PR DESCRIPTION
### Summary

Fixed the failing `test_grpo_config_creation` test by adding the required `reward_funcs` parameter to GRPOTrainer initialization.

### Root Cause

TRL's GRPOTrainer requires `reward_funcs` as a positional argument, expecting a list of reward functions.

### Changes

- **src/training/grpo_trainer.py**: Added `reward_funcs=[self.compute_rewards]` to GRPOTrainer initialization
- Updated comment to reflect the correct parameter name

### Testing

```bash
pytest tests/test_training.py::test_grpo_config_creation -v
```

All 11 tests should now pass.

Related to #28

Generated with [Claude Code](https://claude.ai/code)