### PR TITLE
fix: Mock model config in test_grpo_config_creation

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -113,21 +113,28 @@ def hydra_config():
 
 def test_grpo_config_creation():
     """Test GRPO config creation with default parameters."""
-    trainer = SQLGRPOTrainer(
-        model=Mock(),
-        tokenizer=Mock(),
-        environment=Mock(),
-        rubric=Mock(),
-        train_dataset=Mock()
-    )
+    # Mock GRPOTrainer to avoid initialization issues
+    with patch('src.training.grpo_trainer.GRPOTrainer'):
+        # Create properly mocked model with valid config._name_or_path
+        mock_model = Mock()
+        mock_model.config = Mock()
+        mock_model.config._name_or_path = "meta-llama/Llama-3-8B"
 
-    config = trainer.create_default_config()
+        trainer = SQLGRPOTrainer(
+            model=mock_model,
+            tokenizer=Mock(),
+            environment=Mock(),
+            rubric=Mock(),
+            train_dataset=Mock()
+        )
 
-    assert config.num_train_epochs == 3
-    assert config.per_device_train_batch_size == 1
-    assert config.gradient_accumulation_steps == 8
-    assert config.learning_rate == 5e-6
-    assert config.num_generations == 4
+        config = trainer.create_default_config()
+
+        assert config.num_train_epochs == 3
+        assert config.per_device_train_batch_size == 1
+        assert config.gradient_accumulation_steps == 8
+        assert config.learning_rate == 5e-6
+        assert config.num_generations == 4
 
 
 def test_grpo_config_from_hydra(hydra_config):


### PR DESCRIPTION
### Summary

Fixed the failing `test_grpo_config_creation` test by properly mocking the model object.

### Root Cause

The test was failing because GRPOTrainer internally calls `AutoProcessor.from_pretrained(model.config._name_or_path)`, and the Mock object's `_name_or_path` attribute was returning an invalid string that failed HuggingFace's repo ID validation.

### Changes

- **tests/test_training.py**: Updated `test_grpo_config_creation` to properly mock the model object
  - Wrapped test with `patch('src.training.grpo_trainer.GRPOTrainer')`
  - Set `model.config._name_or_path = "meta-llama/Llama-3-8B"` with a valid HuggingFace repo ID

### Testing

```bash
pytest tests/test_training.py::test_grpo_config_creation -v
```

All 11 tests should now pass.

Related to #28

Generated with [Claude Code](https://claude.ai/code)