### PR TITLE
fix: Remove src. prefix from imports in all scripts

### DIFF
--- a/scripts/analyze_data.py
+++ b/scripts/analyze_data.py
@@ -21,7 +21,7 @@ import re
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from datasets import load_from_disk
-from src.utils.logging_utils import setup_logging
+from utils.logging_utils import setup_logging
 
 
 def analyze_complexity_distribution(dataset):

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -12,9 +12,9 @@ import sys
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.data.dataset_loader import SQLDatasetLoader
-from src.data.preprocessor import SQLDataPreprocessor
-from src.utils.logging_utils import setup_logging
+from data.dataset_loader import SQLDatasetLoader
+from data.preprocessor import SQLDataPreprocessor
+from utils.logging_utils import setup_logging
 
 
 @hydra.main(version_base=None, config_path="../config", config_name="config")

--- a/scripts/test_environment.py
+++ b/scripts/test_environment.py
@@ -18,9 +18,9 @@ import hydra
 from omegaconf import DictConfig
 from datasets import load_dataset
 
-from src.environments.sql_env import TextToSQLEnvironment
-from src.rubrics.sql_rubric import SQLValidationRubric
-from src.utils.sql_parser import SQLParser
+from environments.sql_env import TextToSQLEnvironment
+from rubrics.sql_rubric import SQLValidationRubric
+from utils.sql_parser import SQLParser
 
 
 @hydra.main(version_base=None, config_path="../config", config_name="config")

--- a/scripts/test_model.py
+++ b/scripts/test_model.py
@@ -17,13 +17,13 @@ load_dotenv()
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.models.model_loader import ModelLoader
-from src.models.config_utils import (
+from models.model_loader import ModelLoader
+from models.config_utils import (
     create_bnb_config_from_hydra,
     create_lora_config_from_hydra,
     estimate_memory_requirements
 )
-from src.utils.logging_utils import setup_logging_from_config
+from utils.logging_utils import setup_logging_from_config
 
 
 @hydra.main(version_base=None, config_path="../config", config_name="config")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -7,19 +7,19 @@ import torch
 from pathlib import Path
 from datasets import load_from_disk
 
-from src.models.model_loader import ModelLoader
-from src.models.config_utils import (
+from models.model_loader import ModelLoader
+from models.config_utils import (
     create_bnb_config_from_hydra,
     create_lora_config_from_hydra
 )
-from src.data.grpo_formatter import GRPODatasetFormatter
-from src.environments.sql_env.environment import TextToSQLEnvironment
-from src.rubrics.sql_rubric import SQLValidationRubric
-from src.utils.sql_parser import SQLParser
-from src.training.grpo_trainer import SQLGRPOTrainer
-from src.training.config_builder import GRPOConfigBuilder
-from src.training.callbacks import SQLEvaluationCallback, WandbLoggingCallback
-from src.utils.logging_utils import setup_logging
+from data.grpo_formatter import GRPODatasetFormatter
+from environments.sql_env.environment import TextToSQLEnvironment
+from rubrics.sql_rubric import SQLValidationRubric
+from utils.sql_parser import SQLParser
+from training.grpo_trainer import SQLGRPOTrainer
+from training.config_builder import GRPOConfigBuilder
+from training.callbacks import SQLEvaluationCallback, WandbLoggingCallback
+from utils.logging_utils import setup_logging
 
 try:
     import wandb


### PR DESCRIPTION
### Summary

Fixed import paths in all scripts to align with the package structure defined in setup.py.

### Changes

- Updated **scripts/train.py**: Main training script (12 imports fixed)
- Updated **scripts/analyze_data.py**: Data analysis script (1 import fixed)
- Updated **scripts/prepare_data.py**: Data preparation script (3 imports fixed)
- Updated **scripts/test_environment.py**: Environment testing script (3 imports fixed)
- Updated **scripts/test_model.py**: Model testing script (4 imports fixed)

### Root Cause

The `setup.py` configures `package_dir={"": "src"}`, which means the `src/` directory is the package root. All imports should be without the `src.` prefix.

Before: `from src.models.model_loader import ModelLoader`
After: `from models.model_loader import ModelLoader`

### Testing

```bash
python scripts/train.py
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)