### PR TITLE
fix: Convert all relative imports to absolute imports

### DIFF
--- a/src/data/grpo_formatter.py
+++ b/src/data/grpo_formatter.py
@@ -9,7 +9,7 @@ import logging
 from datasets import Dataset
 import numpy as np
 
-from ..environments.sql_env.environment import TextToSQLEnvironment
+from environments.sql_env.environment import TextToSQLEnvironment
 
 
 logger = logging.getLogger(__name__)

--- a/src/data/preprocessor.py
+++ b/src/data/preprocessor.py
@@ -11,7 +11,7 @@ import re
 import logging
 from datasets import Dataset
 
-from ..utils.sql_parser import SQLParser
+from utils.sql_parser import SQLParser
 
 
 logger = logging.getLogger(__name__)

--- a/src/environments/sql_env/environment.py
+++ b/src/environments/sql_env/environment.py
@@ -10,8 +10,8 @@ from typing import Dict, List, Any, Optional
 
 from verifiers import SingleTurnEnv
 
-from ...rubrics.sql_rubric import SQLValidationRubric
-from ...utils.sql_parser import SQLParser
+from rubrics.sql_rubric import SQLValidationRubric
+from utils.sql_parser import SQLParser
 from .prompts import (
     PROMPT_TEMPLATES,
     get_prompt_template,

--- a/src/rubrics/sql_rubric.py
+++ b/src/rubrics/sql_rubric.py
@@ -12,7 +12,7 @@ import sqlparse
 from sqlparse import sql as sql_tokens
 from sqlparse.exceptions import SQLParseError
 
-from ..utils.sql_parser import SQLParser
+from utils.sql_parser import SQLParser
 
 
 logger = logging.getLogger(__name__)

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -8,8 +8,8 @@ from typing import Dict, Any
 import logging
 import torch
 
-from ..environments.sql_env.environment import TextToSQLEnvironment
-from ..rubrics.sql_rubric import SQLValidationRubric
+from environments.sql_env.environment import TextToSQLEnvironment
+from rubrics.sql_rubric import SQLValidationRubric
 
 try:
     import wandb

--- a/src/training/grpo_trainer.py
+++ b/src/training/grpo_trainer.py
@@ -9,8 +9,8 @@ from typing import Dict, List, Optional, Any
 import logging
 from datasets import Dataset
 
-from ..environments.sql_env.environment import TextToSQLEnvironment
-from ..rubrics.sql_rubric import SQLValidationRubric
+from environments.sql_env.environment import TextToSQLEnvironment
+from rubrics.sql_rubric import SQLValidationRubric
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Summary

Fixed `ImportError: attempted relative import beyond top-level package` when running training script after `pip install -e .`

### Root Cause

The `package_dir={"": "src"}` configuration in setup.py means that everything inside `src/` is treated as the package root. Relative imports like `from ..utils` try to go above the package root, causing the ImportError.

### Changes

Converted all relative imports to absolute imports:
- `from ..utils.sql_parser` → `from utils.sql_parser`
- `from ..environments.sql_env` → `from environments.sql_env`
- `from ..rubrics.sql_rubric` → `from rubrics.sql_rubric`
- `from ...rubrics` → `from rubrics`
- `from ...utils` → `from utils`

### Files Modified
- src/data/preprocessor.py
- src/data/grpo_formatter.py
- src/environments/sql_env/environment.py
- src/rubrics/sql_rubric.py
- src/training/callbacks.py
- src/training/grpo_trainer.py

### Testing

All three commands now work without import errors:
```bash
python scripts/train.py
python scripts/train.py dataset.split.train="train[:100]" training.max_steps=10
python scripts/train.py training.per_device_train_batch_size=16
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)