### PR TITLE
fix: Remove src. prefix from imports in models/__init__.py

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,8 +4,8 @@ This module provides components for loading language models with QLoRA
 quantization and LoRA adapters for efficient fine-tuning.
 """
 
-from src.models.model_loader import ModelLoader
-from src.models.config_utils import (
+from models.model_loader import ModelLoader
+from models.config_utils import (
     create_model_config_from_hydra,
     create_bnb_config_from_hydra,
     create_lora_config_from_hydra,


### PR DESCRIPTION
### Summary

Fixed `ModuleNotFoundError: No module named 'models'` by removing the `src.` prefix from imports in `src/models/__init__.py`.

### Root Cause

The `package_dir={"": "src"}` configuration in setup.py means that `src/` is the package root. All imports should be without the `src.` prefix.

Before: `from src.models.model_loader import ModelLoader`
After: `from models.model_loader import ModelLoader`

### Changes

- Updated `src/models/__init__.py` to use absolute imports without `src.` prefix

### Testing

After merging, users need to reinstall the package:
```bash
pip install -e .
python scripts/train.py
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)