### PR TITLE
fix: Update TRL version requirement to >=0.24.0 for GRPO support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torch>=2.1.0
 transformers>=4.36.0
 datasets>=2.14.0
 accelerate>=0.25.0
-trl>=0.7.0
+trl>=0.24.0
 peft>=0.7.0
 bitsandbytes>=0.41.0
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "transformers>=4.36.0",
         "datasets>=2.14.0",
         "accelerate>=0.25.0",
-        "trl>=0.7.0",
+        "trl>=0.24.0",
         "peft>=0.7.0",
         "bitsandbytes>=0.41.0",
         "verifiers>=0.1.0",


### PR DESCRIPTION
### Summary

Updated TRL version requirement from `trl>=0.7.0` to `trl>=0.24.0` to enable GRPO support.

### Changes

- Updated `setup.py`: Changed trl requirement to >=0.24.0
- Updated `requirements.txt`: Changed trl requirement to >=0.24.0

### Root Cause

The `GRPOConfig` and `GRPOTrainer` classes are only available in TRL version 0.24.0 and later. The previous requirement of `trl>=0.7.0` allowed installation of older versions that don't include GRPO support.

### Testing

After merging, users should upgrade TRL:
```bash
pip install --upgrade trl
# or
pip install -e .
```

Then verify the import works:
```python
from trl import GRPOConfig, GRPOTrainer
```

Related to #28

Generated with [Claude Code](https://claude.ai/code)