### PR TITLE
fix: Use setup_logging_from_config for Hydra config

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -19,7 +19,7 @@ from utils.sql_parser import SQLParser
 from training.grpo_trainer import SQLGRPOTrainer
 from training.config_builder import GRPOConfigBuilder
 from training.callbacks import SQLEvaluationCallback, WandbLoggingCallback
-from utils.logging_utils import setup_logging
+from utils.logging_utils import setup_logging_from_config
 
 try:
     import wandb
@@ -44,7 +44,7 @@ def train(cfg: DictConfig):
     7. Train model
     8. Save and evaluate
     """
-    logger = setup_logging(cfg)
+    logger = setup_logging_from_config(cfg)
     logger.info("="*80)
     logger.info("Starting GRPO Training for Text-to-SQL")
     logger.info("="*80)


### PR DESCRIPTION
### Summary

Fixed `ConfigAttributeError: Key 'upper' is not in struct` when running the training script.

### Root Cause

The train.py script was calling `setup_logging(cfg)` with the entire Hydra config object, but that function expects individual string parameters. This caused a ConfigAttributeError when it tried to call `.upper()` on the DictConfig object.

### Changes

- Updated import in `scripts/train.py` from `setup_logging` to `setup_logging_from_config`
- Updated function call at line 47 from `setup_logging(cfg)` to `setup_logging_from_config(cfg)`

### Testing

```bash
python scripts/train.py
```

The logging configuration will now be properly extracted from the Hydra config.

Related to #28

Generated with [Claude Code](https://claude.ai/code)