### PR TITLE
fix: Filter non-string values in SQLValidationRubric sql_keywords

### DIFF
--- a/src/rubrics/sql_rubric.py
+++ b/src/rubrics/sql_rubric.py
@@ -71,7 +71,12 @@ class SQLValidationRubric:
                 "LIMIT", "OFFSET", "UNION", "DISTINCT", "AS", "ON"
             ]
 
-        self.sql_keywords = [kw.upper() for kw in sql_keywords]
+        # Filter out non-string values (e.g., boolean true/false from config parsing)
+        # and convert to uppercase
+        self.sql_keywords = [
+            kw.upper() for kw in sql_keywords
+            if isinstance(kw, str)
+        ]
 
         # Validate weights sum to 1.0
         total_weight = syntax_weight + keyword_weight + format_weight


### PR DESCRIPTION
### Summary

Fixed `AttributeError: 'bool' object has no attribute 'upper'` that occurred during training initialization.

### Root Cause

The Hydra config parser was including a boolean `true` value in the `sql_keywords` list, which caused an error when the code tried to call `.upper()` on it.

### Changes

- Updated `src/rubrics/sql_rubric.py` to filter out non-string values from `sql_keywords` before processing
- Added type checking with `isinstance(kw, str)` to ensure only strings are processed

### Testing

```bash
python scripts/train.py
```

The training script should now proceed past the rubric initialization step.

Related to #28

Generated with [Claude Code](https://claude.ai/code)