### PR TITLE
fix: Pass dataset parameters to TextToSQLEnvironment

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -114,7 +114,9 @@ def train(cfg: DictConfig):
         parser=parser,
         prompt_template=cfg.training.environment.prompt_template,
         include_schema=cfg.training.environment.include_schema,
-        max_examples=cfg.training.environment.few_shot_examples
+        max_examples=cfg.training.environment.few_shot_examples,
+        dataset=dataset['train'],
+        eval_dataset=dataset.get('validation')
     )
 
     # Format dataset for GRPO


### PR DESCRIPTION
### Summary

Fixed `ValueError: Either dataset or eval_dataset must be provided` that occurred during GRPO training initialization.

### Root Cause

The TextToSQLEnvironment class inherits from verifiers.SingleTurnEnv, which requires at least one of `dataset` or `eval_dataset` to be provided at initialization. The training script was not passing these parameters.

### Changes

- Updated `scripts/train.py` to pass `dataset=dataset['train']` and `eval_dataset=dataset.get('validation')` to TextToSQLEnvironment initialization

### Testing

```bash
python scripts/train.py
```

The training script should now proceed past the environment initialization step.

Related to #28

Generated with [Claude Code](https://claude.ai/code)