### PR TITLE
fix: Convert lm_head.weight.data directly to fix BFloat16 dtype mismatch

### DIFF
--- a/src/models/model_loader.py
+++ b/src/models/model_loader.py
@@ -212,13 +212,19 @@ class ModelLoader:
             self.logger.info("Preparing model for k-bit training")
             model = prepare_model_for_kbit_training(model)
 
-            # Fix dtype mismatch: Cast lm_head to match compute dtype when using quantization
+            # Fix dtype mismatch: Cast lm_head weight to match compute dtype when using quantization
             # This prevents "expected scalar type Float but found BFloat16" errors
             if use_quantization and bnb_config is not None:
                 compute_dtype = bnb_config.bnb_4bit_compute_dtype
                 if hasattr(model, 'lm_head') and model.lm_head is not None:
-                    model.lm_head = model.lm_head.to(compute_dtype)
-                    self.logger.info(f"Cast lm_head to {compute_dtype} to match compute dtype")
+                    # Convert the weight parameter directly (not just the module)
+                    if hasattr(model.lm_head, 'weight') and model.lm_head.weight is not None:
+                        model.lm_head.weight.data = model.lm_head.weight.data.to(compute_dtype)
+                        self.logger.info(f"Cast lm_head.weight to {compute_dtype} to match compute dtype")
+                    else:
+                        # Fallback to module-level casting if weight is not accessible
+                        model.lm_head = model.lm_head.to(compute_dtype)
+                        self.logger.info(f"Cast lm_head module to {compute_dtype} to match compute dtype")
 
             if lora_config is None:
                 lora_config = self.create_lora_config()


### PR DESCRIPTION
### Summary

Fixed persistent `RuntimeError: expected scalar type Float but found BFloat16` error during GRPO training by directly converting the lm_head.weight.data tensor.

### Root Cause

The previous fix attempted to cast the lm_head module using `.to(compute_dtype)`, but this didn't properly convert the underlying weight parameter. The weight tensor remained in Float32 while hidden states were computed in BFloat16, causing a dtype mismatch during the forward pass.

### Changes

- Updated `src/models/model_loader.py` to directly convert `lm_head.weight.data` to the compute dtype
- Changed from `model.lm_head = model.lm_head.to(compute_dtype)` to `model.lm_head.weight.data = model.lm_head.weight.data.to(compute_dtype)`
- Added fallback to module-level casting if weight is not accessible

### Testing

```bash
git pull origin claude/issue-28-20251019-0055
pip install -e .
python scripts/train.py
```

You should see in the logs:
```
Cast lm_head.weight to torch.bfloat16 to match compute dtype
```

Training should now proceed without the dtype mismatch error.

Related to #28

Generated with [Claude Code](https://claude.ai/code)