### PR TITLE
fix: resolve pre-commit Python version mismatch and flake8 errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -12,10 +12,10 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.8.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/scripts/analyze_errors.py
+++ b/scripts/analyze_errors.py
@@ -3,7 +3,6 @@ Analyze evaluation errors and generate insights.
 """
 import argparse
 import json
-from collections import Counter
 from pathlib import Path
 
 import pandas as pd

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -4,14 +4,14 @@ Benchmark multiple model checkpoints on test dataset.
 import sys
 from pathlib import Path
 
-# Add project root to Python path
-project_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(project_root))
-
 import hydra
 import pandas as pd
 from datasets import load_from_disk
 from omegaconf import DictConfig
+
+# Add project root to Python path
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
 
 from src.evaluation.evaluator import SQLEvaluator
 from src.evaluation.metrics import SQLMetrics

--- a/scripts/publish_to_hub.py
+++ b/scripts/publish_to_hub.py
@@ -7,7 +7,7 @@ import logging
 import os
 from pathlib import Path
 
-from huggingface_hub import HfApi, create_repo, upload_folder
+from huggingface_hub import create_repo, upload_folder
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -156,9 +156,6 @@ def publish_model(model_path: str, repo_name: str, private: bool = True, token: 
         token = os.getenv("HF_TOKEN")
         if token is None:
             raise ValueError("HF_TOKEN not found in environment")
-
-    # Initialize API
-    api = HfApi(token=token)
 
     # Create repository
     logger.info(f"Creating repository: {repo_name}")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,7 +4,6 @@ Main training script for GRPO fine-tuning.
 from pathlib import Path
 
 import hydra
-import torch
 from datasets import load_from_disk
 from omegaconf import DictConfig, OmegaConf
 
@@ -13,7 +12,7 @@ from environments.sql_env.environment import TextToSQLEnvironment
 from models.config_utils import create_bnb_config_from_hydra, create_lora_config_from_hydra
 from models.model_loader import ModelLoader
 from rubrics.sql_rubric import SQLValidationRubric
-from training.callbacks import SQLEvaluationCallback, WandbLoggingCallback
+from training.callbacks import SQLEvaluationCallback
 from training.config_builder import GRPOConfigBuilder
 from training.grpo_trainer import SQLGRPOTrainer
 from utils.logging_utils import setup_logging_from_config

--- a/src/data/dataset_loader.py
+++ b/src/data/dataset_loader.py
@@ -9,7 +9,7 @@ import logging
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 from datasets import Dataset, DatasetDict, load_dataset

--- a/src/data/grpo_formatter.py
+++ b/src/data/grpo_formatter.py
@@ -5,7 +5,7 @@ creating prompts and structuring data for reinforcement learning.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 import numpy as np
 from datasets import Dataset

--- a/src/data/preprocessor.py
+++ b/src/data/preprocessor.py
@@ -7,7 +7,7 @@ and SQL normalization.
 
 import logging
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import sqlparse
 from datasets import Dataset

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -4,7 +4,7 @@ Comprehensive SQL evaluation metrics.
 import logging
 from collections import Counter
 from difflib import SequenceMatcher
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 import numpy as np
 import sqlparse

--- a/src/inference/cli.py
+++ b/src/inference/cli.py
@@ -6,7 +6,6 @@ with schema loading, syntax highlighting, and result visualization.
 
 import argparse
 import logging
-from typing import Optional
 
 from rich.console import Console
 from rich.panel import Panel

--- a/src/inference/inference_engine.py
+++ b/src/inference/inference_engine.py
@@ -7,7 +7,7 @@ from natural language questions using fine-tuned models.
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import torch
 from peft import PeftModel

--- a/src/models/model_loader.py
+++ b/src/models/model_loader.py
@@ -6,7 +6,7 @@ memory-efficient fine-tuning on A100 GPUs.
 """
 
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 from peft import LoraConfig, TaskType, get_peft_model, prepare_model_for_kbit_training
@@ -164,7 +164,7 @@ class ModelLoader:
             if torch.cuda.is_available():
                 try:
                     # Test if flash_attn can be imported
-                    import flash_attn
+                    import flash_attn  # noqa: F401
 
                     attn_impl = "flash_attention_2"
                     self.logger.info("Using Flash Attention 2 for improved performance")

--- a/src/rubrics/batch_scorer.py
+++ b/src/rubrics/batch_scorer.py
@@ -5,7 +5,7 @@ with support for parallel processing and caching.
 """
 
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 from .sql_rubric import SQLValidationRubric

--- a/src/rubrics/sql_rubric.py
+++ b/src/rubrics/sql_rubric.py
@@ -9,7 +9,6 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 import sqlparse
-from sqlparse import sql as sql_tokens
 from sqlparse.exceptions import SQLParseError
 
 from utils.sql_parser import SQLParser

--- a/src/training/config_builder.py
+++ b/src/training/config_builder.py
@@ -4,7 +4,6 @@ Builds GRPOConfig from Hydra configuration files.
 """
 
 import logging
-from typing import Optional
 
 from omegaconf import DictConfig
 from trl import GRPOConfig


### PR DESCRIPTION
## Summary

Fixed pre-commit Python version compatibility issue and resolved all 19 flake8 linting errors.

## Changes

- ✅ Updated `.pre-commit-config.yaml` to use `python3` instead of `python3.10`
- ✅ Updated pre-commit-hooks (v4.4.0 → v4.6.0) and black (23.7.0 → 24.8.0)
- ✅ Removed 16 unused imports (F401 errors) across 13 files
- ✅ Fixed import ordering in `scripts/benchmark.py` (E402 errors)
- ✅ Removed unused variable in `scripts/publish_to_hub.py` (F841 error)

## Testing

After these changes:
- `pre-commit run --all-files` works with Python 3.11
- `make lint` passes without errors

Resolves issue raised in #57

🤖 Generated with [Claude Code](https://claude.ai/code)