### PR TITLE
fix: resolve E402 flake8 errors and mypy pre-commit dependency issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,5 +33,4 @@ repos:
     rev: v1.5.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-all]
         args: [--ignore-missing-imports]

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -13,10 +13,10 @@ from omegaconf import DictConfig
 project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.evaluation.evaluator import SQLEvaluator
-from src.evaluation.metrics import SQLMetrics
-from src.inference.inference_engine import SQLInferenceEngine
-from src.utils.logging_utils import setup_logging_from_config
+from src.evaluation.evaluator import SQLEvaluator  # noqa: E402
+from src.evaluation.metrics import SQLMetrics  # noqa: E402
+from src.inference.inference_engine import SQLInferenceEngine  # noqa: E402
+from src.utils.logging_utils import setup_logging_from_config  # noqa: E402
 
 
 @hydra.main(version_base=None, config_path="../config", config_name="config")


### PR DESCRIPTION
## Summary

Fixed remaining linting and pre-commit configuration issues.

## Changes

- Added `# noqa: E402` comments to imports in `scripts/benchmark.py` that require sys.path modification
- Removed deprecated `types-all` package from mypy pre-commit hook

## Testing

After these changes:
- `make lint` passes without E402 errors
- `pre-commit run --all-files` installs and runs successfully

Resolves #57

🤖 Generated with [Claude Code](https://claude.ai/code)