### PR TITLE
fix: correct relative imports to use src. prefix

### DIFF
--- a/src/data/preprocessor.py
+++ b/src/data/preprocessor.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import sqlparse
 from datasets import Dataset
 
-from utils.sql_parser import SQLParser
+from src.utils.sql_parser import SQLParser
 
 logger = logging.getLogger(__name__)
 

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, Optional
 import torch
 from transformers import TrainerCallback, TrainerControl, TrainerState
 
-from environments.sql_env.environment import TextToSQLEnvironment
-from rubrics.sql_rubric import SQLValidationRubric
+from src.environments.sql_env.environment import TextToSQLEnvironment
+from src.rubrics.sql_rubric import SQLValidationRubric
 
 try:
     import wandb  # type: ignore

--- a/src/training/grpo_trainer.py
+++ b/src/training/grpo_trainer.py
@@ -10,8 +10,8 @@ from typing import Any, Dict, List, Optional
 from datasets import Dataset
 from trl import GRPOConfig, GRPOTrainer
 
-from environments.sql_env.environment import TextToSQLEnvironment
-from rubrics.sql_rubric import SQLValidationRubric
+from src.environments.sql_env.environment import TextToSQLEnvironment
+from src.rubrics.sql_rubric import SQLValidationRubric
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes ModuleNotFoundError issues preventing tests from running.

## Changes

- Fixed import in `src/data/preprocessor.py`: `utils.sql_parser` → `src.utils.sql_parser`
- Fixed imports in `src/training/callbacks.py`: `environments/rubrics` → `src.environments/src.rubrics`
- Fixed imports in `src/training/grpo_trainer.py`: `environments/rubrics` → `src.environments/src.rubrics`

All imports now use the correct `src.` prefix for absolute imports from the project root.

Resolves #57

Generated with [Claude Code](https://claude.ai/code)