### PR TITLE
fix: update test assertion to match float return type

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -231,7 +231,7 @@ class TestSQLEvaluator:
         assert 'token_accuracy' in metrics
         assert 'structural_similarity' in metrics
         assert 'keyword_f1' in metrics
-        assert metrics['exact_match'] is True
+        assert metrics['exact_match'] == 1.0
 
     def test_compute_aggregate_metrics(self):
         """Test computing aggregate metrics."""


### PR DESCRIPTION
Fixes failing test `test_compute_sample_metrics` by updating assertion to match the float return type of exact_match metric.

The evaluator now returns exact_match as a float (1.0) instead of boolean (True). Updated the test assertion from identity check (is True) to equality check (== 1.0).

Resolves #57

Generated with [Claude Code](https://claude.ai/code)